### PR TITLE
add create-apikey command

### DIFF
--- a/src/commands/create-apikey.ts
+++ b/src/commands/create-apikey.ts
@@ -14,7 +14,7 @@ export default class CreateApikey extends BaseCommand {
   static flags = {
     ...BaseCommand.commonFlags,
     name: flags.string({char: 'n', description: 'Client name', default: 'slash-graphql-cli'}),
-    isAdmin: flags.boolean({char: 'a', description: 'Grant admin role', default: false})
+    admin: flags.boolean({char: 'a', description: 'Grant admin role', default: false})
   }
 
   static args = [{name: 'id', description: 'Backend id', required: true}]
@@ -47,7 +47,7 @@ export default class CreateApikey extends BaseCommand {
       },
       body: JSON.stringify({
         name: opts.args.name,
-        role: opts.args.isAdmin ? 'admin' : 'client'
+        role: opts.args.admin ? 'admin' : 'client'
       })
     })
     if (response.status !== 200) {

--- a/src/commands/create-apikey.ts
+++ b/src/commands/create-apikey.ts
@@ -1,0 +1,62 @@
+import {BaseCommand} from '../lib'
+import {getEnvironment} from '../lib/environments'
+import {flags} from '@oclif/command'
+import fetch from 'node-fetch'
+import {cli} from 'cli-ux'
+
+export default class CreateApikey extends BaseCommand {
+  static description = 'Create an API key for a Backend by id'
+
+  static examples = [
+    '$ slash-graphql create-apikey "0xid"',
+  ]
+
+  static flags = {
+    ...BaseCommand.commonFlags,
+    name: flags.string({char: 'n', description: 'Client name', default: 'slash-graphql-cli'}),
+    isAdmin: flags.boolean({char: 'a', description: 'Grant admin role', default: false})
+  }
+
+  static args = [{name: 'id', description: 'Backend id', required: true}]
+
+  async run() {
+    const opts = this.parse(CreateApikey)
+    const {apiServer, authFile} = getEnvironment(opts.flags.environment)
+
+    const id = opts.args.id
+
+    if (!id.match(/0x[0-9a-f]+/)) {
+      this.error(`Invalid id ${id}`)
+    }
+
+    const token = await this.getAccessToken(apiServer, authFile)
+    if (!token) {
+      this.error('Please login with `slash-graphql login`')
+    }
+
+    const backend = this.findBackendByUid(apiServer, token, id)
+
+    if (!backend) {
+      this.error('Cannot find the backend that you are trying to create an API key for. Please run `slash-graphql list-backends` to get a list of backends')
+    }
+
+    const response = await fetch(`${apiServer}/deployment/${id}/api-keys`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        name: opts.args.name,
+        role: opts.args.isAdmin ? 'admin' : 'client'
+      })
+    })
+    if (response.status !== 200) {
+      this.error(`Unable to create API key. Try logging in again\n${await response.text()}`)
+    }
+    const apiKey = await response.json() as APIKey
+
+    if (!opts.flags.quiet) {
+      this.log(apiKey.key)
+    }
+  }
+}

--- a/src/commands/create-apikey.ts
+++ b/src/commands/create-apikey.ts
@@ -6,6 +6,7 @@ import {cli} from 'cli-ux'
 
 export default class CreateApikey extends BaseCommand {
   static description = 'Create an API key for a Backend by id'
+  static hidden = true
 
   static examples = [
     '$ slash-graphql create-apikey "0xid"',
@@ -14,7 +15,7 @@ export default class CreateApikey extends BaseCommand {
   static flags = {
     ...BaseCommand.commonFlags,
     name: flags.string({char: 'n', description: 'Client name', default: 'slash-graphql-cli'}),
-    admin: flags.boolean({char: 'a', description: 'Grant admin role', default: false})
+    role: flags.string({char: 'r', description: 'Client role', default: 'client', options: ['admin', 'client']})
   }
 
   static args = [{name: 'id', description: 'Backend id', required: true}]
@@ -47,7 +48,7 @@ export default class CreateApikey extends BaseCommand {
       },
       body: JSON.stringify({
         name: opts.args.name,
-        role: opts.args.admin ? 'admin' : 'client'
+        role: opts.args.role
       })
     })
     if (response.status !== 200) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,6 +7,13 @@ interface APIBackend {
   owner: string;
 }
 
+interface APIKey {
+  key: string;
+  name: string;
+  role: string;
+  uid: string;
+}
+
 interface AuthConfig {
   apiTime: number;
   access_token: string;


### PR DESCRIPTION
This PR adds a `create-apikey` command, modeled after the `destroy-backend` command. It requires an `id`, and optionally can be passed in a `name` and/or `admin` flag. If successful, it returns a newly-created API key.