### PR TITLE
Fix typo in API url

### DIFF
--- a/src/commands/create-apikey.ts
+++ b/src/commands/create-apikey.ts
@@ -44,7 +44,8 @@ export default class CreateApikey extends BaseCommand {
     const response = await fetch(`${apiServer}/deployments/${id}/api-keys`, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
       },
       body: JSON.stringify({
         name: opts.flags.name,

--- a/src/commands/create-apikey.ts
+++ b/src/commands/create-apikey.ts
@@ -41,7 +41,7 @@ export default class CreateApikey extends BaseCommand {
       this.error('Cannot find the backend that you are trying to create an API key for. Please run `slash-graphql list-backends` to get a list of backends')
     }
 
-    const response = await fetch(`${apiServer}/deployment/${id}/api-keys`, {
+    const response = await fetch(`${apiServer}/deployments/${id}/api-keys`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/commands/create-apikey.ts
+++ b/src/commands/create-apikey.ts
@@ -47,8 +47,8 @@ export default class CreateApikey extends BaseCommand {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        name: opts.args.name,
-        role: opts.args.role
+        name: opts.flags.name,
+        role: opts.flags.role
       })
     })
     if (response.status !== 200) {


### PR DESCRIPTION
It turns out there's both `/deployments/<id>` and `/deployment/<id>`, and the `create-apikey` used the wrong one!

Also fix a typo when passing the _flags_ (not _args_) into the API call.