### PR TITLE
Don't open default browsers. Log a clickable link instead

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,5 +1,4 @@
 import fetch from 'node-fetch'
-import open = require('open')
 import sleep = require('sleep-promise')
 import {BaseCommand} from '../lib'
 import {getEnvironment} from '../lib/environments'
@@ -29,7 +28,7 @@ export default class Login extends BaseCommand {
       return
     }
     const deviceCode = await deviceCodeResponse.json()
-    open(deviceCode.verification_uri_complete)
+    this.log('Please visit the following URL in your browser of choice:' deviceCode.verification_uri_complete)
     this.log('You should see the following code in your browser:', deviceCode.user_code)
 
     const token = await this.pollForToken(apiServer, deviceCode)


### PR DESCRIPTION
https://discuss.dgraph.io/t/slash-graphql-cli-opens-browsers-on-the-users-behalf-this-breaks-workflows/12925/2