### PR TITLE
docs(README): Deprecate the slash-graphql CLI tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 **The slash-graphql CLI tool is deprecated and no longer maintained.**
 
+You can now manage your Cloud backends using the [Dgraph Cloud API](https://dgraph.io/docs/cloud/cloud-api/).
 # slash-graphql
 
 Manage Slash GraphQL from the comfort of your command line!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**The slash-graphql CLI tool is deprecated and no longer maintained.**
+
 # slash-graphql
 
 Manage Slash GraphQL from the comfort of your command line!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 **The slash-graphql CLI tool is deprecated and no longer maintained.**
 
-You can now manage your Cloud backends using the [Dgraph Cloud API](https://dgraph.io/docs/cloud/cloud-api/).
+You can now manage your Dgraph Cloud backends using the [Dgraph Cloud API](https://dgraph.io/docs/cloud/cloud-api/).
+
 # slash-graphql
 
 Manage Slash GraphQL from the comfort of your command line!


### PR DESCRIPTION
The `slash-graphql` command-line tool is no longer maintained. This repository will be archived once this PR is merged.